### PR TITLE
Original research: STM computation and Kalman Sensitivity now computed using Dual Numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ flate2 = { version = "1.0", features = ["rust_backend"], default-features = fals
 rand = "0.5"
 serde = "1.0"
 csv = "1"
+dual_num = "0.2"
 
 [dev-dependencies]
 pretty_env_logger = "0.2"

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2018 Christopher B. Rabotin
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -199,3 +199,20 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+   Commons Clause Restriction
+
+   The Software is provided to you by the Licensor under the License, as defined below, subject to
+   the following condition.
+   Without limiting other conditions in the License, the grant of rights under the License will not
+   include, and the License does not grant to you, the right to Sell the Software.
+   For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you
+   under the License to provide to third parties, for a fee or other consideration (including without
+   limitation fees for hosting or consulting/ support services related to the Software), a product or
+   service whose value derives, entirely or substantially, from the functionality of the Software.
+   Any license notice or attribution required by the License must also include this Commons Cause
+   License Condition notice.
+
+   For purposes of the clause above, the “Licensor” is Christopher B. Rabotin, the “License” is the Apache
+   License, Version 2.0, and the Software is the nyx library, toolkit and examples provided with this
+   notice.

--- a/LICENSE
+++ b/LICENSE
@@ -210,7 +210,7 @@
    under the License to provide to third parties, for a fee or other consideration (including without
    limitation fees for hosting or consulting/ support services related to the Software), a product or
    service whose value derives, entirely or substantially, from the functionality of the Software.
-   Any license notice or attribution required by the License must also include this Commons Cause
+   Any license notice or attribution required by the License must also include this Commons Clause
    License Condition notice.
 
    For purposes of the clause above, the “Licensor” is Christopher B. Rabotin, the “License” is the Apache

--- a/src/celestia/mod.rs
+++ b/src/celestia/mod.rs
@@ -9,8 +9,8 @@ pub trait CelestialBody {
     fn gm() -> f64;
     /// Returns the equatorial radius of this celestial object.
     fn eq_radius() -> f64;
-    /// Returns the flatenning of this celestial object.
-    fn flatenning() -> f64;
+    /// Returns the flattening of this celestial object.
+    fn flattening() -> f64;
 }
 
 /// `NAIF` represents an object which has a NAIF ID and can be loaded from an SPK file.

--- a/src/celestia/planets.rs
+++ b/src/celestia/planets.rs
@@ -13,7 +13,7 @@ impl CelestialBody for MERCURY {
     fn eq_radius() -> f64 {
         2439.7
     }
-    fn flatenning() -> f64 {
+    fn flattening() -> f64 {
         0.0
     }
 }
@@ -34,7 +34,7 @@ impl CelestialBody for VENUS {
     fn eq_radius() -> f64 {
         6051.9
     }
-    fn flatenning() -> f64 {
+    fn flattening() -> f64 {
         0.0
     }
 }
@@ -67,7 +67,7 @@ impl CelestialBody for EARTH {
     fn eq_radius() -> f64 {
         6378.1363
     }
-    fn flatenning() -> f64 {
+    fn flattening() -> f64 {
         // From [EMG2008](http://earth-info.nga.mil/GandG/wgs84/gravitymod/egm2008/egm08_wgs84.html)
         0.0033528106647474805
     }
@@ -89,7 +89,7 @@ impl CelestialBody for MARS {
     fn eq_radius() -> f64 {
         3.397e3
     }
-    fn flatenning() -> f64 {
+    fn flattening() -> f64 {
         0.00647630
     }
 }
@@ -110,7 +110,7 @@ impl CelestialBody for JUPITER {
     fn eq_radius() -> f64 {
         7.1492e4
     }
-    fn flatenning() -> f64 {
+    fn flattening() -> f64 {
         0.06487439
     }
 }
@@ -131,7 +131,7 @@ impl CelestialBody for SATURN {
     fn eq_radius() -> f64 {
         6.0268e4
     }
-    fn flatenning() -> f64 {
+    fn flattening() -> f64 {
         0.09796243
     }
 }
@@ -152,7 +152,7 @@ impl CelestialBody for URANUS {
     fn eq_radius() -> f64 {
         2.5559e4
     }
-    fn flatenning() -> f64 {
+    fn flattening() -> f64 {
         0.02292734
     }
 }
@@ -173,7 +173,7 @@ impl CelestialBody for NEPTUNE {
     fn eq_radius() -> f64 {
         2.5269e4
     }
-    fn flatenning() -> f64 {
+    fn flattening() -> f64 {
         0.01856029
     }
 }

--- a/src/celestia/state.rs
+++ b/src/celestia/state.rs
@@ -14,6 +14,7 @@ use utils::{between_0_360, between_pm_180};
 use std::f64::consts::PI;
 use std::f64::EPSILON;
 use std::fmt;
+use std::ops::Sub;
 
 /// If an orbit has an eccentricity below the following value, it is considered circular (only affects warning messages)
 pub const ECC_EPSILON: f64 = 1e-4;
@@ -63,6 +64,29 @@ impl<F: CoordinateFrame> PartialEq for State<F> {
             && (self.vx - other.vx).abs() < velocity_tol
             && (self.vy - other.vy).abs() < velocity_tol
             && (self.vz - other.vz).abs() < velocity_tol
+    }
+}
+
+impl<F: CoordinateFrame> Sub for State<F> {
+    type Output = State<F>;
+
+    /// Two states are equal if their position are equal within one centimeter and their velocities within one centimeter per second.
+    /// For time equality, we're relying on the high fidelity time computation of `hifitime` provided through the `Instant` representation.
+    fn sub(self, other: State<F>) -> State<F>
+    where
+        F: CoordinateFrame,
+    {
+        State {
+            gm: self.gm,
+            x: self.x - other.x,
+            y: self.y - other.y,
+            z: self.z - other.z,
+            vx: self.vx - other.vx,
+            vy: self.vy - other.vy,
+            vz: self.vz - other.vz,
+            dt: self.dt,
+            frame: self.frame,
+        }
     }
 }
 

--- a/src/celestia/state.rs
+++ b/src/celestia/state.rs
@@ -624,16 +624,16 @@ impl State<ECEF> {
     /// Creates a new State from the geodetic latitude (φ), longitude (λ) and height with respect to Earth's ellipsoid.
     ///
     /// **Units:** degrees, degrees, km
-    /// NOTE: This computation differs from the spherical coordinates because we consider the flatenning of Earth.
+    /// NOTE: This computation differs from the spherical coordinates because we consider the flattening of Earth.
     /// Reference: G. Xu and Y. Xu, "GPS", DOI 10.1007/978-3-662-50367-6_2, 2016
     pub fn from_geodesic<T: TimeSystem>(latitude: f64, longitude: f64, height: f64, dt: T) -> State<ECEF> {
-        let e2 = 2.0 * EARTH::flatenning() - EARTH::flatenning().powi(2);
+        let e2 = 2.0 * EARTH::flattening() - EARTH::flattening().powi(2);
         let (sin_long, cos_long) = longitude.to_radians().sin_cos();
         let (sin_lat, cos_lat) = latitude.to_radians().sin_cos();
         // page 144
         let c_earth = EARTH::semi_major_radius() / ((1.0 - e2 * sin_lat.powi(2)).sqrt());
         let s_earth =
-            (EARTH::semi_major_radius() * (1.0 - EARTH::flatenning()).powi(2)) / ((1.0 - e2 * sin_lat.powi(2)).sqrt());
+            (EARTH::semi_major_radius() * (1.0 - EARTH::flattening()).powi(2)) / ((1.0 - e2 * sin_lat.powi(2)).sqrt());
         let ri = (c_earth + height) * cos_lat * cos_long;
         let rj = (c_earth + height) * cos_lat * sin_long;
         let rk = (s_earth + height) * sin_lat;
@@ -690,7 +690,7 @@ impl State<ECEF> {
         let mut attempt_no = 0;
         let r_delta = (self.x.powi(2) + self.y.powi(2)).sqrt();
         let mut latitude = (self.z / self.rmag()).asin();
-        let e2 = EARTH::flatenning() * (2.0 - EARTH::flatenning());
+        let e2 = EARTH::flattening() * (2.0 - EARTH::flattening());
         loop {
             attempt_no += 1;
             let c_earth = EARTH::semi_major_radius() / ((1.0 - e2 * (latitude).sin().powi(2)).sqrt());
@@ -712,13 +712,13 @@ impl State<ECEF> {
     ///
     /// Reference: Vallado, 4th Ed., Algorithm 12 page 172.
     pub fn geodetic_height(&self) -> f64 {
-        let e2 = EARTH::flatenning() * (2.0 - EARTH::flatenning());
+        let e2 = EARTH::flattening() * (2.0 - EARTH::flattening());
         let latitude = self.geodetic_latitude().to_radians();
         let sin_lat = latitude.sin();
         if (latitude - 1.0).abs() < 0.1 {
             // We are near poles, let's use another formulation.
             let s_earth =
-                (EARTH::semi_major_radius() * (1.0 - EARTH::flatenning()).powi(2)) / ((1.0 - e2 * sin_lat.powi(2)).sqrt());
+                (EARTH::semi_major_radius() * (1.0 - EARTH::flattening()).powi(2)) / ((1.0 - e2 * sin_lat.powi(2)).sqrt());
             self.z / latitude.sin() - s_earth
         } else {
             let c_earth = EARTH::semi_major_radius() / ((1.0 - e2 * sin_lat.powi(2)).sqrt());

--- a/src/dynamics/celestial.rs
+++ b/src/dynamics/celestial.rs
@@ -232,7 +232,7 @@ impl<'a> AutoDiffDynamics for TwoBodyWithDualStm<'a> {
         for i in 0..3 {
             let this_radius = Vector3::new(radius[(0, i)], radius[(1, i)], radius[(2, i)]);
             let this_norm = norm(&this_radius);
-            let this_body_acceleration = this_radius * Dual::from_real(self.mu) / this_norm.powi(3);
+            let this_body_acceleration = this_radius * Dual::from_real(-self.mu) / this_norm.powi(3);
             body_acceleration.set_column(i, &this_body_acceleration);
         }
 

--- a/src/dynamics/celestial.rs
+++ b/src/dynamics/celestial.rs
@@ -1,8 +1,12 @@
+extern crate dual_num;
 extern crate nalgebra as na;
-use self::na::{Matrix6, MatrixMN, U3, U36, U42, U6, Vector6, VectorN};
+
+use self::dual_num::linalg::norm;
+use self::dual_num::{Dual, Float};
+use self::na::{Matrix3x6, Matrix6, MatrixMN, U3, U36, U42, U6, Vector3, Vector6, VectorN};
 use super::Dynamics;
 use celestia::{CelestialBody, CoordinateFrame, State};
-use od::Linearization;
+use od::{AutoDiffDynamics, Linearization};
 use std::f64;
 use std::sync::mpsc::Sender;
 
@@ -67,7 +71,7 @@ impl<'a> Dynamics for TwoBody<'a> {
     }
 }
 
-/// `TwoBody` exposes the equations of motion for a simple two body propagation. It inherently supports
+/// `TwoBodyWithStm` exposes the equations of motion for a simple two body propagation. It inherently supports
 /// the State Transition Matrix for orbital determination.
 #[derive(Clone)]
 pub struct TwoBodyWithStm<'a> {
@@ -190,5 +194,114 @@ impl<'a> Linearization for TwoBodyWithStm<'a> {
         grad[(5, 2)] = daz_dz;
 
         grad
+    }
+}
+
+#[derive(Clone)]
+pub struct TwoBodyWithDualStm<'a> {
+    pub stm: Matrix6<f64>,
+    pub two_body_dyn: TwoBody<'a>,
+    pub tx_chan: Option<&'a Sender<(f64, Vector6<f64>, Matrix6<f64>)>>,
+}
+
+impl<'a> TwoBodyWithDualStm<'a> {
+    /// Initialize TwoBody dynamics around a provided `CelestialBody` from the provided position and velocity state (cf. nyx::celestia).
+    pub fn from_state<B: CelestialBody, F: CoordinateFrame>(state: State<F>) -> TwoBodyWithDualStm<'a> {
+        TwoBodyWithDualStm {
+            stm: Matrix6::identity(),
+            two_body_dyn: TwoBody::from_state_vec::<B>(state.to_cartesian_vec()),
+            tx_chan: None,
+        }
+    }
+}
+
+impl<'a> AutoDiffDynamics for TwoBodyWithDualStm<'a> {
+    type HyperStateSize = U6;
+
+    /// Defines the equations of motion for Dual numbers for these dynamics.
+    fn dual_eom(&self, _t: f64, state: &Matrix6<Dual<f64>>) -> Matrix6<Dual<f64>> {
+        let radius = state.fixed_slice::<U3, U6>(0, 0).into_owned();
+        let velocity = state.fixed_slice::<U3, U6>(3, 0).into_owned();
+
+        let mut body_acceleration = Matrix3x6::zeros();
+
+        for i in 0..3 {
+            let this_radius = Vector3::new(radius[(0, i)], radius[(1, i)], radius[(2, i)]);
+            let this_norm = norm(&this_radius);
+            let this_body_acceleration = this_radius * Dual::from_real(self.two_body_dyn.mu) / this_norm.powi(3);
+            body_acceleration.set_column(i, &this_body_acceleration);
+        }
+
+        let mut rtn = Matrix6::zeros();
+
+        for i in 0..6 {
+            if i < 3 {
+                rtn.set_row(i, &velocity.row(i));
+            } else {
+                rtn.set_row(i, &body_acceleration.row(i - 3));
+            }
+        }
+        rtn
+    }
+}
+
+impl<'a> Dynamics for TwoBodyWithDualStm<'a> {
+    type StateSize = U42;
+    fn time(&self) -> f64 {
+        self.two_body_dyn.time()
+    }
+
+    fn state(&self) -> VectorN<f64, Self::StateSize> {
+        let mut stm_as_vec = VectorN::<f64, U36>::zeros();
+        let mut stm_idx = 0;
+        for i in 0..6 {
+            for j in 0..6 {
+                stm_as_vec[(stm_idx, 0)] = self.stm[(i, j)];
+                stm_idx += 1;
+            }
+        }
+        VectorN::<f64, Self::StateSize>::from_iterator(self.two_body_dyn.state().iter().chain(stm_as_vec.iter()).cloned())
+    }
+
+    fn set_state(&mut self, new_t: f64, new_state: &VectorN<f64, Self::StateSize>) {
+        let pos_vel = new_state.fixed_rows::<U6>(0).into_owned();
+        self.two_body_dyn.set_state(new_t, &pos_vel);
+        let mut stm_k_to_0 = Matrix6::zeros();
+        let mut stm_idx = 6;
+        for i in 0..6 {
+            for j in 0..6 {
+                stm_k_to_0[(i, j)] = new_state[(stm_idx, 0)];
+                stm_idx += 1;
+            }
+        }
+        let mut stm_prev = self.stm.clone();
+        if !stm_prev.try_inverse_mut() {
+            panic!("STM not invertible");
+        }
+        self.stm = stm_k_to_0 * stm_prev;
+
+        match self.tx_chan {
+            Some(ref chan) => match chan.send((new_t, pos_vel.clone(), self.stm.clone())) {
+                Err(e) => warn!("could not publish to channel: {}", e),
+                Ok(_) => {}
+            },
+            _ => {}
+        }
+    }
+
+    fn eom(&self, t: f64, state: &VectorN<f64, Self::StateSize>) -> VectorN<f64, Self::StateSize> {
+        let pos_vel = state.fixed_rows::<U6>(0).into_owned();
+        let two_body_dt = self.two_body_dyn.eom(t, &pos_vel);
+        let stm_dt = self.stm * self.gradient(t, &pos_vel);
+        // Rebuild the STM as a vector.
+        let mut stm_as_vec = VectorN::<f64, U36>::zeros();
+        let mut stm_idx = 0;
+        for i in 0..6 {
+            for j in 0..6 {
+                stm_as_vec[(stm_idx, 0)] = stm_dt[(i, j)];
+                stm_idx += 1;
+            }
+        }
+        VectorN::<f64, Self::StateSize>::from_iterator(two_body_dt.iter().chain(stm_as_vec.iter()).cloned())
     }
 }

--- a/src/od/mod.rs
+++ b/src/od/mod.rs
@@ -79,7 +79,6 @@ where
 
     /// Defines the equations of motion for Dual numbers for these dynamics.
     fn dual_eom(
-        &self,
         t: f64,
         state: &MatrixMN<Dual<f64>, Self::HyperStateSize, Self::HyperStateSize>,
     ) -> MatrixMN<Dual<f64>, Self::HyperStateSize, Self::HyperStateSize>
@@ -90,17 +89,17 @@ where
             + Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>;
 }
 
-impl<T: AutoDiff> Linearization for T {
+impl<T: AutoDiff> Linearization for T
+where
+    DefaultAllocator: Allocator<Dual<f64>, T::HyperStateSize> + Allocator<Dual<f64>, T::HyperStateSize, T::HyperStateSize>,
+{
     type StateSize = T::HyperStateSize;
 
     fn gradient(&self, t: f64, state: &VectorN<f64, Self::StateSize>) -> MatrixMN<f64, Self::StateSize, Self::StateSize>
     where
-        DefaultAllocator: Allocator<Dual<f64>, Self::StateSize>
-            + Allocator<Dual<f64>, Self::StateSize, Self::StateSize>
-            + Allocator<f64, Self::StateSize>
-            + Allocator<f64, Self::StateSize, Self::StateSize>,
+        DefaultAllocator: Allocator<f64, Self::StateSize> + Allocator<f64, Self::StateSize, Self::StateSize>,
     {
-        let (_, grad) = partials_t(t, *state, Self::dual_eom);
+        let (_, grad) = partials_t(t, state.clone(), Self::dual_eom);
         grad
     }
 }

--- a/src/od/mod.rs
+++ b/src/od/mod.rs
@@ -8,6 +8,7 @@ use self::hifitime::instant::Instant;
 use self::na::allocator::Allocator;
 use self::na::{DefaultAllocator, DimName, MatrixMN, VectorN};
 use celestia::{CoordinateFrame, State};
+use dynamics::Dynamics;
 
 /// Provides the Kalman filters. The [examples](https://github.com/ChristopherRabotin/nyx/tree/master/examples) folder may help in the setup.
 pub mod kalman;
@@ -70,7 +71,7 @@ where
 /// A trait container to specify that given dynamics support linearization, and can be used for state transition matrix computation.
 ///
 /// This trait will likely be made obsolete after the implementation of [#32](https://github.com/ChristopherRabotin/nyx/issues/32).
-pub trait AutoDiffDynamics
+pub trait AutoDiffDynamics: Dynamics
 where
     Self: Sized,
 {
@@ -88,30 +89,43 @@ where
             + Allocator<Dual<f64>, Self::HyperStateSize, Self::HyperStateSize>
             + Allocator<f64, Self::HyperStateSize>
             + Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>;
-}
 
-impl<T: AutoDiffDynamics> Linearization for T
-where
-    DefaultAllocator: Allocator<Dual<f64>, T::HyperStateSize> + Allocator<Dual<f64>, T::HyperStateSize, T::HyperStateSize>,
-{
-    type StateSize = T::HyperStateSize;
-
-    fn gradient(&self, t: f64, state: &VectorN<f64, Self::StateSize>) -> MatrixMN<f64, Self::StateSize, Self::StateSize>
+    /// Returns the state of the dynamics (does **not** include the STM, use Dynamics::state() for that)
+    fn dynamics_state(&self) -> VectorN<f64, Self::HyperStateSize>
     where
-        DefaultAllocator: Allocator<f64, Self::StateSize> + Allocator<f64, Self::StateSize, Self::StateSize>,
+        DefaultAllocator: Allocator<f64, Self::HyperStateSize>;
+
+    /// Set the state of the dynamics (does **not** include the STM, use Dynamics::set_state() for that)
+    fn set_dynamics_state(&mut self, state: VectorN<f64, Self::HyperStateSize>)
+    where
+        DefaultAllocator: Allocator<f64, Self::HyperStateSize>;
+
+    /// Returns the gradient of the dynamics.
+    fn dynamics_gradient(&self) -> MatrixMN<f64, Self::HyperStateSize, Self::HyperStateSize>
+    where
+        DefaultAllocator: Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>;
+
+    /// Set the gradient of the dynamics
+    fn set_dynamics_gradient(&mut self, gradient: MatrixMN<f64, Self::HyperStateSize, Self::HyperStateSize>)
+    where
+        DefaultAllocator: Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>;
+
+    /// Computes both the state and the gradient of the dynamics. These may be accessed by the related
+    /// getters.
+    fn compute(&mut self, t: f64, state: &VectorN<f64, Self::HyperStateSize>)
+    where
+        DefaultAllocator: Allocator<Dual<f64>, Self::HyperStateSize>
+            + Allocator<Dual<f64>, Self::HyperStateSize, Self::HyperStateSize>
+            + Allocator<f64, Self::HyperStateSize>
+            + Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>,
     {
-        // XXX: This is a copy/paste (with minor modifications) of dual_num::partials_t
-        // We aren't using partials_t here because the function definition does not match that of dual_eom.
-        // Specifically, we would have to create a trait in the dual_num package to allow for partials_t
-        // to support a &self parameter in the function call.
-
         // Create a Matrix for the hyperdual space
-        let mut hyperdual_space = MatrixMN::<Dual<f64>, Self::StateSize, Self::StateSize>::zeros();
+        let mut hyperdual_space = MatrixMN::<Dual<f64>, Self::HyperStateSize, Self::HyperStateSize>::zeros();
 
-        for i in 0..Self::StateSize::dim() {
-            let mut v_i = VectorN::<Dual<f64>, Self::StateSize>::zeros();
+        for i in 0..Self::HyperStateSize::dim() {
+            let mut v_i = VectorN::<Dual<f64>, Self::HyperStateSize>::zeros();
 
-            for j in 0..Self::StateSize::dim() {
+            for j in 0..Self::HyperStateSize::dim() {
                 v_i[(j, 0)] = Dual::new(state[(j, 0)], if i == j { 1.0 } else { 0.0 });
             }
 
@@ -121,14 +135,49 @@ where
         let state_n_grad = self.dual_eom(t, &hyperdual_space);
 
         // Extract the dual part
-        let mut grad = MatrixMN::<f64, Self::StateSize, Self::StateSize>::zeros();
+        let mut state = VectorN::<f64, Self::HyperStateSize>::zeros();
+        let mut grad = MatrixMN::<f64, Self::HyperStateSize, Self::HyperStateSize>::zeros();
 
-        for i in 0..Self::StateSize::dim() {
-            for j in 0..Self::StateSize::dim() {
+        for i in 0..Self::HyperStateSize::dim() {
+            for j in 0..Self::HyperStateSize::dim() {
+                if j == 0 {
+                    // The state is duplicated in every column
+                    state[(i, 0)] = state_n_grad[(i, 0)].real();
+                }
+
                 grad[(i, j)] = state_n_grad[(i, j)].dual();
             }
         }
+        self.set_dynamics_state(state);
+        self.set_dynamics_gradient(grad);
+    }
 
-        grad
+    /// Returns the real part of the equations of motion for these dynamics.
+    fn real_eom(&mut self, t: f64, state: &VectorN<f64, Self::HyperStateSize>) -> VectorN<f64, Self::HyperStateSize>
+    where
+        DefaultAllocator: Allocator<Dual<f64>, Self::HyperStateSize>
+            + Allocator<Dual<f64>, Self::HyperStateSize, Self::HyperStateSize>
+            + Allocator<f64, Self::HyperStateSize>
+            + Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>,
+    {
+        self.compute(t, state);
+        self.dynamics_state()
+    }
+}
+
+impl<T: AutoDiffDynamics> Linearization for T
+where
+    DefaultAllocator: Allocator<Dual<f64>, T::StateSize> + Allocator<Dual<f64>, T::StateSize, T::StateSize>,
+{
+    type StateSize = T::HyperStateSize;
+
+    /// Returns the gradient of the dynamics at the given state.
+    ///
+    /// **WARNING:** Requires a prior call to self.compute() ! This is where the auto-differentiation happens.
+    fn gradient(&self, t: f64, state: &VectorN<f64, Self::StateSize>) -> MatrixMN<f64, Self::StateSize, Self::StateSize>
+    where
+        DefaultAllocator: Allocator<f64, Self::StateSize> + Allocator<f64, Self::StateSize, Self::StateSize>,
+    {
+        self.dynamics_gradient()
     }
 }

--- a/src/od/mod.rs
+++ b/src/od/mod.rs
@@ -43,13 +43,7 @@ where
     type MeasurementSize: DimName;
 
     /// Computes a new measurement from the provided information.
-    fn new<F: CoordinateFrame>(
-        dt: Instant,
-        tx: State<F>,
-        rx: State<F>,
-        obs: VectorN<f64, Self::MeasurementSize>,
-        visible: bool,
-    ) -> Self;
+    fn new<F: CoordinateFrame>(dt: Instant, tx: State<F>, rx: State<F>, visible: bool) -> Self;
 
     /// Returns the measurement/observation as a vector.
     fn observation(&self) -> &VectorN<f64, Self::MeasurementSize>
@@ -148,7 +142,7 @@ where
     /// Returns the gradient of the dynamics at the given state.
     ///
     /// **WARNING:** Requires a prior call to self.compute() ! This is where the auto-differentiation happens.
-    fn gradient(&self, t: f64, state: &VectorN<f64, Self::StateSize>) -> MatrixMN<f64, Self::StateSize, Self::StateSize>
+    fn gradient(&self, _t: f64, _state: &VectorN<f64, Self::StateSize>) -> MatrixMN<f64, Self::StateSize, Self::StateSize>
     where
         DefaultAllocator: Allocator<f64, Self::StateSize> + Allocator<f64, Self::StateSize, Self::StateSize>,
     {

--- a/src/od/mod.rs
+++ b/src/od/mod.rs
@@ -90,29 +90,16 @@ where
             + Allocator<f64, Self::HyperStateSize>
             + Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>;
 
-    /// Returns the state of the dynamics (does **not** include the STM, use Dynamics::state() for that)
-    fn dynamics_state(&self) -> VectorN<f64, Self::HyperStateSize>
-    where
-        DefaultAllocator: Allocator<f64, Self::HyperStateSize>;
-
-    /// Set the state of the dynamics (does **not** include the STM, use Dynamics::set_state() for that)
-    fn set_dynamics_state(&mut self, state: VectorN<f64, Self::HyperStateSize>)
-    where
-        DefaultAllocator: Allocator<f64, Self::HyperStateSize>;
-
-    /// Returns the gradient of the dynamics.
-    fn dynamics_gradient(&self) -> MatrixMN<f64, Self::HyperStateSize, Self::HyperStateSize>
-    where
-        DefaultAllocator: Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>;
-
-    /// Set the gradient of the dynamics
-    fn set_dynamics_gradient(&mut self, gradient: MatrixMN<f64, Self::HyperStateSize, Self::HyperStateSize>)
-    where
-        DefaultAllocator: Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>;
-
     /// Computes both the state and the gradient of the dynamics. These may be accessed by the related
     /// getters.
-    fn compute(&mut self, t: f64, state: &VectorN<f64, Self::HyperStateSize>)
+    fn compute(
+        &self,
+        t: f64,
+        state: &VectorN<f64, Self::HyperStateSize>,
+    ) -> (
+        VectorN<f64, Self::HyperStateSize>,
+        MatrixMN<f64, Self::HyperStateSize, Self::HyperStateSize>,
+    )
     where
         DefaultAllocator: Allocator<Dual<f64>, Self::HyperStateSize>
             + Allocator<Dual<f64>, Self::HyperStateSize, Self::HyperStateSize>
@@ -148,20 +135,7 @@ where
                 grad[(i, j)] = state_n_grad[(i, j)].dual();
             }
         }
-        self.set_dynamics_state(state);
-        self.set_dynamics_gradient(grad);
-    }
-
-    /// Returns the real part of the equations of motion for these dynamics.
-    fn real_eom(&mut self, t: f64, state: &VectorN<f64, Self::HyperStateSize>) -> VectorN<f64, Self::HyperStateSize>
-    where
-        DefaultAllocator: Allocator<Dual<f64>, Self::HyperStateSize>
-            + Allocator<Dual<f64>, Self::HyperStateSize, Self::HyperStateSize>
-            + Allocator<f64, Self::HyperStateSize>
-            + Allocator<f64, Self::HyperStateSize, Self::HyperStateSize>,
-    {
-        self.compute(t, state);
-        self.dynamics_state()
+        (state, grad)
     }
 }
 
@@ -178,6 +152,6 @@ where
     where
         DefaultAllocator: Allocator<f64, Self::StateSize> + Allocator<f64, Self::StateSize, Self::StateSize>,
     {
-        self.dynamics_gradient()
+        panic!("retrieve the gradient by calling self.compute(...)");
     }
 }

--- a/tests/orbitaldyn.rs
+++ b/tests/orbitaldyn.rs
@@ -7,8 +7,8 @@ fn two_body_parametrized() {
     extern crate nalgebra as na;
     use self::na::Vector6;
     use nyx::celestia::EARTH;
-    use nyx::dynamics::Dynamics;
     use nyx::dynamics::celestial::TwoBody;
+    use nyx::dynamics::Dynamics;
     use nyx::propagators::*;
 
     let prop_time = 24.0 * 3_600.0;
@@ -35,8 +35,8 @@ fn two_body_parametrized() {
 fn two_body_custom() {
     extern crate nalgebra as na;
     use self::na::Vector6;
-    use nyx::dynamics::Dynamics;
     use nyx::dynamics::celestial::TwoBody;
+    use nyx::dynamics::Dynamics;
     use nyx::propagators::*;
 
     let prop_time = 24.0 * 3_600.0;
@@ -44,14 +44,14 @@ fn two_body_custom() {
     let min_step = 0.1;
     let max_step = 60.0;
 
-    let rslt = Vector6::from_row_slice(&[
+    let rslt = Vector6::new(
         -5971.1941916712285,
         3945.5066532419537,
         2864.636618390466,
         0.04909695760948815,
         -4.1850933184621315,
         5.848940867758592,
-    ]);
+    );
 
     let mut prop = Propagator::new::<RK89>(&Options::with_adaptive_step(min_step, max_step, accuracy));
     let mut dyn = TwoBody::from_state_vec_with_gm(
@@ -65,11 +65,11 @@ fn two_body_custom() {
 #[test]
 fn two_body_state_parametrized() {
     extern crate nalgebra as na;
-    use hifitime::SECONDS_PER_DAY;
     use hifitime::julian::ModifiedJulian;
+    use hifitime::SECONDS_PER_DAY;
     use nyx::celestia::{State, EARTH, ECI};
-    use nyx::dynamics::Dynamics;
     use nyx::dynamics::celestial::TwoBody;
+    use nyx::dynamics::Dynamics;
     use nyx::propagators::{error_ctrl, Options, Propagator, RK89};
 
     let dt = ModifiedJulian { days: 21545.0 };
@@ -103,4 +103,64 @@ fn two_body_state_parametrized() {
     assert_eq!(final_state, rslt, "two body prop failed",);
 
     println!("Final state:\n{0}\n{0:o}", final_state);
+}
+
+#[test]
+fn two_body_dual() {
+    // This is a duplicate of the differentials test in dual_num.
+    extern crate nalgebra as na;
+    use self::na::{Matrix6, Vector6};
+    use hifitime::julian::ModifiedJulian;
+    use nyx::celestia::{State, EARTH, ECI};
+    use nyx::dynamics::celestial::TwoBodyWithDualStm;
+    use nyx::od::AutoDiffDynamics;
+
+    let init = State::from_cartesian_eci(
+        -9042.862233600335,
+        18536.333069123244,
+        6999.9570694864115,
+        -3.28878900377057,
+        -2.226285193102822,
+        1.6467383807226765,
+        ModifiedJulian { days: 21546.0 },
+    );
+
+    let expected_fx = Vector6::new(
+        -3.28878900377057,
+        -2.226285193102822,
+        1.6467383807226765,
+        0.0003488751720191492,
+        -0.0007151349009902908,
+        -0.00027005954128877916,
+    );
+
+    let dyn = TwoBodyWithDualStm::from_state::<EARTH, ECI>(init);
+    let (fx, grad) = dyn.compute(0.0, &init.to_cartesian_vec());
+
+    assert!(
+        (fx - expected_fx).norm() < 1e-16,
+        "f(x) computation is incorrect ({})",
+        (fx - expected_fx).norm()
+    );
+
+    let mut expected = Matrix6::zeros();
+
+    expected[(0, 3)] = 1.0;
+    expected[(1, 4)] = 1.0;
+    expected[(2, 5)] = 1.0;
+    expected[(3, 0)] = -0.000000018628398676538285;
+    expected[(4, 0)] = -0.00000004089774775108092;
+    expected[(5, 0)] = -0.0000000154443965496673;
+    expected[(3, 1)] = -0.00000004089774775108092;
+    expected[(4, 1)] = 0.000000045253271751873843;
+    expected[(5, 1)] = 0.00000003165839212196757;
+    expected[(3, 2)] = -0.0000000154443965496673;
+    expected[(4, 2)] = 0.00000003165839212196757;
+    expected[(5, 2)] = -0.000000026624873075335538;
+
+    assert!(
+        (grad - expected).norm() < 1e-16,
+        "gradient computation is incorrect {}",
+        (grad - expected).norm()
+    );
 }

--- a/tests/stat_od/two_body.rs
+++ b/tests/stat_od/two_body.rs
@@ -8,7 +8,7 @@ use self::hifitime::julian::*;
 use self::hifitime::SECONDS_PER_DAY;
 use self::na::{Matrix2, Matrix2x6, Matrix6, U42, U6, Vector2, Vector6};
 use self::nyx::celestia::{State, EARTH, ECI};
-use self::nyx::dynamics::celestial::{TwoBody, TwoBodyWithStm};
+use self::nyx::dynamics::celestial::{TwoBody, TwoBodyWithDualStm, TwoBodyWithStm};
 use self::nyx::dynamics::Dynamics;
 use self::nyx::od::kalman::{Estimate, FilterError, KF};
 use self::nyx::od::ranging::GroundStation;
@@ -80,7 +80,7 @@ fn filter_errors() {
 }
 
 #[test]
-fn ckf_fixed_step_perfect_stations() {
+fn ckf_fixed_step_perfect_stations_std() {
     use std::{io, thread};
 
     // Define the ground stations.
@@ -344,6 +344,143 @@ fn ekf_fixed_step_perfect_stations() {
                 let now = tb_estimator.time(); // Needed because we can't do a mutable borrow while doing an immutable one too.
                 let new_state = tb_estimator.two_body_dyn.state() + latest_est.state;
                 tb_estimator.two_body_dyn.set_state(now, &new_state);
+                break; // We know that only one station is in visibility at each time.
+            }
+        }
+        if still_empty {
+            // We're doing perfect everything, so we should always be in visibility
+            panic!("T+{} : not in visibility", this_dt);
+        }
+    }
+}
+
+#[test]
+fn ckf_fixed_step_perfect_stations_dual() {
+    use std::{io, thread};
+
+    // Define the ground stations.
+    let elevation_mask = 0.0;
+    let range_noise = 0.0;
+    let range_rate_noise = 0.0;
+    let dss65_madrid = GroundStation::dss65_madrid(elevation_mask, range_noise, range_rate_noise);
+    let dss34_canberra = GroundStation::dss34_canberra(elevation_mask, range_noise, range_rate_noise);
+    let dss13_goldstone = GroundStation::dss13_goldstone(elevation_mask, range_noise, range_rate_noise);
+    let all_stations = vec![dss65_madrid, dss34_canberra, dss13_goldstone];
+
+    // Define the propagator information.
+    let prop_time = SECONDS_PER_DAY;
+    let step_size = 10.0;
+    let opts = Options::with_fixed_step(step_size);
+
+    // Define the storages (channels for the states and a map for the measurements).
+    let (truth_tx, truth_rx): (Sender<(f64, Vector6<f64>)>, Receiver<(f64, Vector6<f64>)>) = mpsc::channel();
+    let mut measurements = Vec::with_capacity(10000); // Assume that we won't get more than 10k measurements.
+
+    // Define state information.
+    let dt = ModifiedJulian { days: 21545.0 };
+    let initial_state = State::from_keplerian_eci(22000.0, 0.01, 30.0, 80.0, 40.0, 0.0, dt);
+
+    // Generate the truth data on one thread.
+    thread::spawn(move || {
+        let mut prop = Propagator::new::<RK4Fixed>(&opts.clone());
+        let mut dyn = TwoBody::from_state_vec::<EARTH>(initial_state.to_cartesian_vec());
+        dyn.tx_chan = Some(&truth_tx);
+        prop.until_time_elapsed(prop_time, &mut dyn, error_ctrl::rss_step_pos_vel);
+    });
+
+    // Receive the states on the main thread, and populate the measurement channel.
+    let mut prev_dt = dt.into_instant();
+    loop {
+        match truth_rx.recv() {
+            Ok((t, state_vec)) => {
+                // Convert the state to ECI.
+                let this_dt =
+                    ModifiedJulian::from_instant(dt.into_instant() + Instant::from_precise_seconds(t, Era::Present).duration());
+                let rx_state = State::from_cartesian_vec::<EARTH, ModifiedJulian>(&state_vec, this_dt, ECI {});
+                for station in all_stations.iter() {
+                    let meas = station.measure(rx_state, this_dt.into_instant());
+                    if meas.visible() {
+                        // XXX: Instant does not implement Eq, only PartialEq, so can't use it as an index =(
+                        let delta = (prev_dt - this_dt.into_instant().duration()).duration().as_secs();
+                        measurements.push((delta, meas));
+                        prev_dt = this_dt.into_instant();
+                        break; // We know that only one station is in visibility at each time.
+                    }
+                }
+            }
+            Err(_) => {
+                break;
+            }
+        }
+    }
+
+    // Now that we have the truth data, let's start an OD with no noise at all and compute the estimates.
+    // We expect the estimated orbit to be perfect since we're using strictly the same dynamics, no noise on
+    // the measurements, and the same time step.
+    let mut prop_est = Propagator::new::<RK4Fixed>(&opts);
+    let mut tb_estimator = TwoBodyWithDualStm::from_state::<EARTH, ECI>(initial_state);
+    let covar_radius = 1.0e-6;
+    let covar_velocity = 1.0e-6;
+    let init_covar = Matrix6::from_diagonal(&Vector6::new(
+        covar_radius,
+        covar_radius,
+        covar_radius,
+        covar_velocity,
+        covar_velocity,
+        covar_velocity,
+    ));
+
+    let initial_estimate = Estimate {
+        // state: tb_estimator.two_body_dyn.state(),
+        state: Vector6::zeros(),
+        covar: init_covar,
+        stm: tb_estimator.stm.clone(),
+        predicted: false,
+    };
+
+    let measurement_noise = Matrix2::from_diagonal(&Vector2::new(1e-6, 1e-3));
+    let mut ckf = KF::initialize(initial_estimate, measurement_noise);
+
+    println!("Will process {} measurements", measurements.len());
+
+    let mut prev_dt = dt;
+    let mut printed = false;
+
+    let mut wtr = csv::Writer::from_writer(io::stdout());
+
+    for (duration, real_meas) in measurements.iter() {
+        // Propagate the dynamics to the measurement, and then start the filter.
+        let delta_time = (*duration) as f64;
+        prop_est.until_time_elapsed(delta_time, &mut tb_estimator, error_ctrl::largest_error::<U42>);
+        // Update the STM of the KF
+        ckf.update_stm(tb_estimator.stm.clone());
+        // Get the computed observation
+        let this_dt = ModifiedJulian::from_instant(
+            prev_dt.into_instant() + Instant::from_precise_seconds(delta_time, Era::Present).duration(),
+        );
+        if prev_dt == this_dt {
+            panic!("already handled that time: {}", prev_dt);
+        }
+        prev_dt = this_dt;
+        let rx_state = State::from_cartesian_vec::<EARTH, ModifiedJulian>(&tb_estimator.two_body_dyn.state(), this_dt, ECI {});
+        let mut still_empty = true;
+        for station in all_stations.iter() {
+            let computed_meas = station.measure(rx_state, this_dt.into_instant());
+            if computed_meas.visible() {
+                ckf.update_h_tilde(*computed_meas.sensitivity());
+                let latest_est = ckf
+                    .measurement_update(*real_meas.observation(), *computed_meas.observation())
+                    .expect("wut?");
+                still_empty = false;
+                assert_eq!(latest_est.predicted, false, "estimate should not be a prediction");
+                assert!(
+                    latest_est.state.norm() < EPSILON,
+                    "estimate error should be zero (perfect dynamics)"
+                );
+                if !printed {
+                    wtr.serialize(latest_est).expect("could not write to stdout");
+                    printed = true;
+                }
                 break; // We know that only one station is in visibility at each time.
             }
         }

--- a/tests/stat_od/two_body.rs
+++ b/tests/stat_od/two_body.rs
@@ -462,7 +462,7 @@ fn ckf_fixed_step_perfect_stations_dual() {
             panic!("already handled that time: {}", prev_dt);
         }
         prev_dt = this_dt;
-        let rx_state = State::from_cartesian_vec::<EARTH, ModifiedJulian>(&tb_estimator.two_body_dyn.state(), this_dt, ECI {});
+        let rx_state = State::from_cartesian_vec::<EARTH, ModifiedJulian>(&tb_estimator.pos_vel, this_dt, ECI {});
         let mut still_empty = true;
         for station in all_stations.iter() {
             let computed_meas = station.measure(rx_state, this_dt.into_instant());
@@ -475,7 +475,8 @@ fn ckf_fixed_step_perfect_stations_dual() {
                 assert_eq!(latest_est.predicted, false, "estimate should not be a prediction");
                 assert!(
                     latest_est.state.norm() < EPSILON,
-                    "estimate error should be zero (perfect dynamics)"
+                    "estimate error should be zero (perfect dynamics) ({})",
+                    latest_est.state.norm()
                 );
                 if !printed {
                     wtr.serialize(latest_est).expect("could not write to stdout");

--- a/tests/stat_od/two_body.rs
+++ b/tests/stat_od/two_body.rs
@@ -294,7 +294,6 @@ fn ekf_fixed_step_perfect_stations() {
     ));
 
     let initial_estimate = Estimate {
-        // state: tb_estimator.two_body_dyn.state(),
         state: Vector6::zeros(),
         covar: init_covar,
         stm: tb_estimator.stm.clone(),
@@ -431,7 +430,6 @@ fn ckf_fixed_step_perfect_stations_dual() {
     ));
 
     let initial_estimate = Estimate {
-        // state: tb_estimator.two_body_dyn.state(),
         state: Vector6::zeros(),
         covar: init_covar,
         stm: tb_estimator.stm.clone(),

--- a/tests/stat_od/two_body.rs
+++ b/tests/stat_od/two_body.rs
@@ -472,8 +472,8 @@ fn ckf_fixed_step_perfect_stations_dual() {
                 still_empty = false;
                 assert_eq!(latest_est.predicted, false, "estimate should not be a prediction");
                 assert!(
-                    latest_est.state.norm() < EPSILON,
-                    "estimate error should be zero (perfect dynamics) ({})",
+                    latest_est.state.norm() < 1e-9,
+                    "estimate error should be zero (perfect dynamics) ({:e})",
                     latest_est.state.norm()
                 );
                 if !printed {


### PR DESCRIPTION
This allows for faster computation (twice as fast in the test function example), and avoids having to compute the gradient and the partials matrix.

Closes #37 . Closes #32 .