### PR TITLE
Upgrade to hyperdual 0.3.0 (master branch)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ flate2 = { version = "1.0", features = ["rust_backend"], default-features = fals
 rand = "0.6"
 serde = "1.0"
 csv = "1"
-dual_num = "0.2.5"
+dual_num = { git = "https://github.com/novacrazy/dual_num", branch = "issue-18" }
 
 [dev-dependencies]
 pretty_env_logger = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ flate2 = { version = "1.0", features = ["rust_backend"], default-features = fals
 rand = "0.6"
 serde = "1.0"
 csv = "1"
-dual_num = { git = "https://github.com/novacrazy/dual_num", branch = "issue-18" }
+dual_num = { git = "https://github.com/novacrazy/dual_num", branch = "master" }
 
 [dev-dependencies]
 pretty_env_logger = "0.3"

--- a/src/dynamics/celestial.rs
+++ b/src/dynamics/celestial.rs
@@ -2,8 +2,8 @@ extern crate dual_num;
 extern crate nalgebra as na;
 
 use self::dual_num::linalg::norm;
-use self::dual_num::{Dual, Float};
-use self::na::{Matrix3x6, Matrix6, MatrixMN, Vector3, Vector6, VectorN, U3, U36, U42, U6};
+use self::dual_num::{Float, Hyperdual};
+use self::na::{DimName, Matrix3x6, Matrix6, MatrixMN, Vector3, Vector6, VectorN, U3, U36, U42, U6, U7};
 use super::Dynamics;
 use celestia::{CelestialBody, CoordinateFrame, State};
 use od::{AutoDiffDynamics, Linearization};
@@ -217,32 +217,33 @@ impl<'a> TwoBodyWithDualStm<'a> {
 }
 
 impl<'a> AutoDiffDynamics for TwoBodyWithDualStm<'a> {
-    type HyperStateSize = U6;
+    type HyperStateSize = U7;
+    type STMSize = U6;
 
-    /// Defines the equations of motion for Dual numbers for these dynamics.
-    fn dual_eom(&self, _t: f64, state: &Matrix6<Dual<f64>>) -> Matrix6<Dual<f64>> {
-        let radius = state.fixed_slice::<U3, U6>(0, 0).into_owned();
-        let velocity = state.fixed_slice::<U3, U6>(3, 0).into_owned();
+    fn dual_eom(&self, _t: f64, state: &VectorN<Hyperdual<f64, U7>, U6>) -> (Vector6<f64>, Matrix6<f64>) {
+        // Extract data from hyperspace
+        let radius = state.fixed_rows::<U3>(0).into_owned();
+        let velocity = state.fixed_rows::<U3>(3).into_owned();
 
-        let mut body_acceleration = Matrix3x6::zeros();
+        // Code up math as usual
+        let rmag = norm(&radius);
+        let body_acceleration = radius * (Hyperdual::<f64, U7>::from_real(-398_600.4415) / rmag.powi(3));
 
-        for i in 0..3 {
-            let this_radius = Vector3::new(radius[(0, i)], radius[(1, i)], radius[(2, i)]);
-            let this_norm = norm(&this_radius);
-            let this_body_acceleration = this_radius * Dual::from_real(-self.mu) / this_norm.powi(3);
-            body_acceleration.set_column(i, &this_body_acceleration);
-        }
-
-        let mut rtn = Matrix6::zeros();
-
-        for i in 0..6 {
-            if i < 3 {
-                rtn.set_row(i, &velocity.row(i));
+        // Extract result into Vector6 and Matrix6
+        let mut fx = Vector6::zeros();
+        let mut grad = Matrix6::zeros();
+        for i in 0..U6::dim() {
+            fx[i] = if i < 3 {
+                velocity[i].real()
             } else {
-                rtn.set_row(i, &body_acceleration.row(i - 3));
+                body_acceleration[i - 3].real()
+            };
+            for j in 1..U7::dim() {
+                grad[(i, j - 1)] = if i < 3 { velocity[i][j] } else { body_acceleration[i - 3][j] };
             }
         }
-        rtn
+
+        (fx, grad)
     }
 }
 

--- a/src/dynamics/celestial.rs
+++ b/src/dynamics/celestial.rs
@@ -209,7 +209,7 @@ impl AutoDiffDynamics for TwoBodyWithDualStm {
 
         // Code up math as usual
         let rmag = norm(&radius);
-        let body_acceleration = radius * (Hyperdual::<f64, U7>::from_real(-398_600.4415) / rmag.powi(3));
+        let body_acceleration = radius * (Hyperdual::<f64, U7>::from_real(-self.mu) / rmag.powi(3));
 
         // Extract result into Vector6 and Matrix6
         let mut fx = Vector6::zeros();
@@ -270,7 +270,6 @@ impl Dynamics for TwoBodyWithDualStm {
     fn eom(&self, t: f64, state: &VectorN<f64, Self::StateSize>) -> VectorN<f64, Self::StateSize> {
         let pos_vel = state.fixed_rows::<U6>(0).into_owned();
         let (state, grad) = self.compute(t, &pos_vel);
-        let two_body_dt = state;
         let stm_dt = self.stm * grad;
         // Rebuild the STM as a vector.
         let mut stm_as_vec = VectorN::<f64, U36>::zeros();
@@ -281,6 +280,6 @@ impl Dynamics for TwoBodyWithDualStm {
                 stm_idx += 1;
             }
         }
-        VectorN::<f64, Self::StateSize>::from_iterator(two_body_dt.iter().chain(stm_as_vec.iter()).cloned())
+        VectorN::<f64, Self::StateSize>::from_iterator(state.iter().chain(stm_as_vec.iter()).cloned())
     }
 }

--- a/src/od/mod.rs
+++ b/src/od/mod.rs
@@ -86,8 +86,8 @@ where
             + Allocator<Hyperdual<f64, Self::HyperStateSize>, Self::STMSize>,
         Owned<f64, Self::HyperStateSize>: Copy;
 
-    /// Computes both the state and the gradient of the dynamics. These may be accessed by the related
-    /// getters.
+    /// Computes both the state and the gradient of the dynamics. These may be accessed by the
+    /// related getters.
     fn compute(
         &self,
         t: f64,

--- a/src/od/mod.rs
+++ b/src/od/mod.rs
@@ -3,7 +3,7 @@ extern crate hifitime;
 extern crate nalgebra as na;
 extern crate serde;
 
-use self::dual_num::{hyperspace_from_vector, Dual, DualN, Float, FloatConst, Hyperdual, Owned};
+use self::dual_num::{hyperspace_from_vector, Dual, Hyperdual, Owned};
 use self::hifitime::instant::Instant;
 use self::na::allocator::Allocator;
 use self::na::{DefaultAllocator, DimName, MatrixMN, VectorN};
@@ -94,7 +94,11 @@ where
         state: &VectorN<f64, Self::STMSize>,
     ) -> (VectorN<f64, Self::STMSize>, MatrixMN<f64, Self::STMSize, Self::STMSize>)
     where
-        DefaultAllocator: Allocator<f64, Self::STMSize> + Allocator<f64, Self::STMSize, Self::STMSize>,
+        DefaultAllocator: Allocator<f64, Self::HyperStateSize>
+            + Allocator<f64, Self::STMSize>
+            + Allocator<f64, Self::STMSize, Self::STMSize>
+            + Allocator<Hyperdual<f64, Self::HyperStateSize>, Self::STMSize>,
+        Owned<f64, Self::HyperStateSize>: Copy,
     {
         let hyperstate = hyperspace_from_vector(&state);
 

--- a/tests/stat_od/two_body.rs
+++ b/tests/stat_od/two_body.rs
@@ -477,7 +477,7 @@ fn ckf_fixed_step_perfect_stations_dual() {
                 still_empty = false;
                 assert_eq!(latest_est.predicted, false, "estimate should not be a prediction");
                 assert!(
-                    latest_est.state.norm() < 1e-9,
+                    latest_est.state.norm() < EPSILON,
                     "estimate error should be zero (perfect dynamics) ({:e})",
                     latest_est.state.norm()
                 );

--- a/tests/stat_od/two_body.rs
+++ b/tests/stat_od/two_body.rs
@@ -371,7 +371,7 @@ fn ckf_fixed_step_perfect_stations_dual() {
     let all_stations = vec![dss65_madrid, dss34_canberra, dss13_goldstone];
 
     // Define the propagator information.
-    let prop_time = SECONDS_PER_DAY * 365.25;
+    let prop_time = SECONDS_PER_DAY;
     let step_size = 10.0;
     let opts = PropOpts::with_fixed_step(step_size, RSSStepPV {});
 


### PR DESCRIPTION
### Effects
Minor speed improvements. The CKF example took 12.6 seconds (averaged over three runs) for a full year tests, and now only takes 12.3 seconds when switching to hyperdual ranging. When using the hyperdual STM, computation takes 14.6 seconds for that same duration. Although slightly slower (18%), I still expect this to be very valuable when starting to estimate multibody dynamics.

Upon inspection into the traits, I do not envision any other change which may help in speed. The EOMs and the gradient are computed only once and at once. Adding the `#[inline]` directive also did not help =(

No version change needed.

Closes #51

### If this is a new feature or a bug fix ...
- [x] Yes, the branch I'm proposing to merge is called `issue-xyz` where `xyz` is the number of the issue.

### If this change adds or modifies a validation case
- [x] No.
- [ ] Yes and:
  - I have coded up, or updated, an existing test case; and
  - I have provided a GMAT script which confirms the result(s); and
  - I have updated the `VALIDATION.md` file with the new error data between nyx and GMAT.
  - I will specify the version of GMAT used for the validation.
